### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Elv
 ===
 
-.. image:: https://pypip.in/wheel/elv/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/elv.svg
     :target: https://pypi.python.org/pypi/elv/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20elv))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `elv`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.